### PR TITLE
Supplementary file path

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -778,6 +778,24 @@ int payload_main(struct payload_args *args)
     preload_dirents(sock, "/system/priv/lib", g_dirent_buf + (3 * 0x10000));
     preload_dirents(sock, "/system/sys", g_dirent_buf + (4 * 0x10000));
     preload_dirents(sock, "/system/vsh", g_dirent_buf + (5 * 0x10000));
+    preload_dirents(sock, "/system/vsh/app/NPXS40039", g_dirent_buf + (6 * 0x10000));
+    preload_dirents(sock, "/system/vsh/app/NPXS40109", g_dirent_buf + (7 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40000", g_dirent_buf + (8 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40001/psm/Application", g_dirent_buf + (9 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40028", g_dirent_buf + (10 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40074", g_dirent_buf + (11 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40074/psm/Application", g_dirent_buf + (12 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40087", g_dirent_buf + (13 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40087/psm/Application", g_dirent_buf + (14 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40093/psm/Application", g_dirent_buf + (15 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40099", g_dirent_buf + (16 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40099/psm/Application", g_dirent_buf + (17 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40106/psm/Application", g_dirent_buf + (18 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40140", g_dirent_buf + (19 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40140/cdc/bin", g_dirent_buf + (20 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40140/cdc/lib", g_dirent_buf + (21 * 0x10000));
+    preload_dirents(sock, "/system_ex/app/NPXS40140/psm/Application", g_dirent_buf + (22 * 0x10000));
+    preload_dirents(sock, "/system_ex/priv_ex/lib", g_dirent_buf + (23 * 0x10000));
 
     dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (0 * 0x10000), "/", "/mnt/usb0/PS5");
     dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (1 * 0x10000), "/system/common/lib", "/mnt/usb0/PS5/system/common/lib");
@@ -785,7 +803,24 @@ int payload_main(struct payload_args *args)
     dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (3 * 0x10000), "/system/priv/lib", "/mnt/usb0/PS5/system/priv/lib");
     dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (4 * 0x10000), "/system/sys", "/mnt/usb0/PS5/system/sys");
     dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (5 * 0x10000), "/system/vsh", "/mnt/usb0/PS5/system/vsh");
-
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (6 * 0x10000), "/system/vsh/app/NPXS40039", "/mnt/usb0/PS5/system/vsh/app/NPXS40039");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (7 * 0x10000), "/system/vsh/app/NPXS40109", "/mnt/usb0/PS5/system/vsh/app/NPXS40109");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (8 * 0x10000), "/system_ex/app/NPXS40000", "/mnt/usb0/PS5/system_ex/app/NPXS40000");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (9 * 0x10000), "/system_ex/app/NPXS40001/psm/Application", "/mnt/usb0/PS5/system_ex/app/NPXS40001/psm/Application");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (10 * 0x10000), "/system_ex/app/NPXS40028", "/mnt/usb0/PS5/system_ex/app/NPXS40028");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (11 * 0x10000), "/system_ex/app/NPXS40074", "/mnt/usb0/PS5/system_ex/app/NPXS40074");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (12 * 0x10000), "/system_ex/app/NPXS40074/psm/Application", "/mnt/usb0/PS5/system_ex/app/NPXS40074/psm/Application");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (13 * 0x10000), "/system_ex/app/NPXS40087", "/mnt/usb0/PS5/system_ex/app/NPXS40087");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (14 * 0x10000), "/system_ex/app/NPXS40087/psm/Application", "/mnt/usb0/PS5/system_ex/app/NPXS40087/psm/Application");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (15 * 0x10000), "/system_ex/app/NPXS40093/psm/Application", "/mnt/usb0/PS5/system_ex/app/NPXS40093/psm/Application");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (16 * 0x10000), "/system_ex/app/NPXS40099", "/mnt/usb0/PS5/system_ex/app/NPXS40099");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (17 * 0x10000), "/system_ex/app/NPXS40099/psm/Application", "/mnt/usb0/PS5/system_ex/app/NPXS40099/psm/Application");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (18 * 0x10000), "/system_ex/app/NPXS40106/psm/Application", "/mnt/usb0/PS5/system_ex/app/NPXS40106/psm/Application");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (19 * 0x10000), "/system_ex/app/NPXS40140", "/mnt/usb0/PS5/system_ex/app/NPXS40140");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (20 * 0x10000), "/system_ex/app/NPXS40140/cdc/bin", "/mnt/usb0/PS5/system_ex/app/NPXS40140/cdc/bin");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (21 * 0x10000), "/system_ex/app/NPXS40140/cdc/lib", "/mnt/usb0/PS5/system_ex/app/NPXS40140/cdc/lib");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (22 * 0x10000), "/system_ex/app/NPXS40140/psm/Application", "/mnt/usb0/PS5/system_ex/app/NPXS40140/psm/Application");
+    dump_dir(sock, authmgr_handle, &offsets, g_dirent_buf + (23 * 0x10000), "/system_ex/priv_ex/lib", "/mnt/usb0/PS5/system_ex/priv_ex/lib");
     SOCK_LOG(sock, "[+] done!\n");
 
 out:


### PR DESCRIPTION
Added additional elf self sprx paths ,If decryption of system/vsh/app and system_ex/app/*/app.exe.sprx files frequently fails or crashes, copy the files that need to be decrypted to the /data directory and it will resume normal decryption again.（Add the /data directory in main.c）